### PR TITLE
updated broken links of Google Hire and Deskbar

### DIFF
--- a/graveyard.json
+++ b/graveyard.json
@@ -67,7 +67,7 @@
     "dateClose": "2019-09-18",
     "dateOpen": "2017-08-07",
     "description": "YouTube Messages was a direct messaging feature that allowed users to share and discuss videos one-on-one and in groups on YouTube.",
-    "link": "https://9to5google.com/2019/08/20/youtube-killing-messages",
+    "link": "https://thenextweb.com/google/2019/08/22/youtube-messages-feature-killed-off/",
     "name": "YouTube Messages",
     "type": "service"
   },
@@ -171,7 +171,7 @@
     "dateClose": "2006-05-08",
     "dateOpen": "2003-11-10",
     "description": "Google Deskbar was a small inset window on the Windows toolbar and allowed users to perform searches without leaving the desktop.",
-    "link": "https://www.computerweekly.com/news/2240053391/Google-launches-Deskbar-software",
+    "link": "https://gcemetery.co/google-deskbar/",
     "name": "Google Deskbar",
     "type": "service"
   },


### PR DESCRIPTION
I have updated the broken links of Google Hire and Deskbar

<!--

Hello! Thank you for opening a Pull Request! Killed by Google is hosted on Github pages.

Be sure to read Contributing Guide to ensure your PR will pass Continuous Integration.

-->
